### PR TITLE
Updated Time Format in SQL query

### DIFF
--- a/controllers/car_review.controller.js
+++ b/controllers/car_review.controller.js
@@ -4,7 +4,13 @@ exports.findReviewsById = async (req, res) => {
   const modelId = parseInt(req.params.id);
 
   const response = await db.query(
-    "SELECT * FROM car_schema.car_reviews WHERE model_id = $1",
+    "SELECT *," +
+    "CASE WHEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'dd') != '00' THEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'dd \"days ago\"') " +
+    "WHEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'hh24') != '00' THEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'hh24 \"hours ago\"') " +
+    "WHEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'mi') != '00' THEN to_char(timezone('UTC+7'::text, now()) - timestamp, 'mi \"minutes ago\"') " +
+    "ELSE 'Just yet' " +
+    "END as time_formatted " +
+    "FROM car_schema.car_reviews WHERE model_id = $1",
     [modelId]
   );
 


### PR DESCRIPTION
What I Did
- Updated the SQL query for the reviews to get the timestamp in a format of "time ago"

How To Test
- Run https://github.com/Benzy-Clubbers/benzy-clubbers-ember/pull/5
- Test if all timestamps were correctly formatted. Mainly check the model with ID 1, as it's the only one having test reviews now. Note: some of the timestamps are Null which would show "Just yet", and some may be out of time order since time has not been set up properly until recently in the Database
- Post a new review - it must show "Just yet" until one minute passed
- You can test the actual timestamp in Postman by running GET on `http://localhost:3000/cars/reviews/model/1`